### PR TITLE
bg(text description): change the vaccine certificate bio text

### DIFF
--- a/src/app/pages/home/components/vaccine-card-bio/vaccine-card-bio.component.css
+++ b/src/app/pages/home/components/vaccine-card-bio/vaccine-card-bio.component.css
@@ -1,56 +1,56 @@
 .vaccine-card-bio-container {
-	margin-top: 50px;
+  margin-top: 50px;
 }
 .vaccine-card-bio-info {
-	font-size: 1.2rem;
-	text-align: left;
-	padding-right: 20px;
-	padding-left: 20px;
-	overflow-wrap: break-word;
+  font-size: 1.2rem;
+  text-align: left;
+  padding-right: 20px;
+  padding-left: 20px;
+  overflow-wrap: break-word;
 }
 .vaccine-card-bio-location {
-	text-align: center;
-	font-size: 1.2rem;
-	padding-top: 15px;
-	padding-bottom: 15px;
+  text-align: center;
+  font-size: 1.2rem;
+  padding-top: 15px;
+  padding-bottom: 15px;
 }
 
 .horizontal-line {
-	border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid #e5e5e5;
 }
 
 .vaccine-card-bio-value {
-	font-size: 0.8rem;
+  font-size: 0.8rem;
 }
 
 .vaccine-card-bio-title {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 tbody {
-	display: block;
-	overflow-y: auto;
-	overflow-x: hidden;
+  display: block;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 thead,
 tbody tr {
-	display: table;
-	width: 100%;
-	table-layout: fixed;
+  display: table;
+  width: 100%;
+  table-layout: fixed;
 }
 
 th,
 td {
-	padding-left: 10px;
-	padding-top: 15px;
-	padding-bottom: 15px;
-	word-wrap: break-word;
+  padding-left: 10px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  word-wrap: break-word;
 }
 
 th {
-	text-align: center;
+  text-align: center;
 }
 
 table {
-	width: 100%;
+  width: 100%;
 }

--- a/src/app/pages/home/components/vaccine-card-bio/vaccine-card-bio.component.html
+++ b/src/app/pages/home/components/vaccine-card-bio/vaccine-card-bio.component.html
@@ -8,11 +8,10 @@
 				<p>
 					This is to certify that <b>{{ fullName }}</b
 					>, born on <b>{{ dateOfBirth }}</b
-					>, from <b>South Sudan</b> with
-					<b>identification Id: {{ identificationNumber }}</b
-					>, has been vaccinated against <b>Covid 19</b> on date indicated in
+					>, bearing vaccination <b>identification Id: {{ identificationNumber }}</b
+					>, has been vaccinated in <b>South Sudan</b> against <b>Covid 19</b> on date indicated in
 					accordance with the National Health Regulations.
-				</p>
+				</p>	
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
**What does this PR do?**

fix bio text description

**Description of Task to be completed**

Change the bio text description. The current descriptions state as if all vaccinated people are South Sudanese.
The changes in place capture all nationals bearing the vaccination certificate.

**How should this be manually tested?**

clone this repo
cd to the folder
git checkout bg-fix-text-desc
run ```npm i && npm start``` 
go to your browser and type ```localhost:4200``` and navigate the app

**Any background context you want to provide?**

you need to have Angular CLI and typescript  installed
setup the URL and instance credentials on the proxy-config.json file

**What are the relevant pivotal tracker stories?**

 NA

**screenshots**
 preview of the bio text with a sample user
![Screenshot from 2022-01-20 13-25-06](https://user-images.githubusercontent.com/18526493/150330164-ee49b219-4fef-4442-9c56-233d5fb58dde.png)



Closes #9